### PR TITLE
Do not use external dependencies

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const debug = require('debug')('serialize-json#JSONDecoder');
-
 const TOKEN_TRUE = -1;
 const TOKEN_FALSE = -2;
 const TOKEN_NULL = -3;
@@ -39,72 +37,73 @@ class JSONDecoder {
 
   _unpack() {
     const token = this.tokens[this.tokensIndex];
+
     switch (token) {
-      case '@': // array
-      {
-        debug('--> unpack array begin');
+      case '@': {
         const arr = [];
         const tokensLen = this.tokens.length;
+
         for (this.tokensIndex++; this.tokensIndex < tokensLen; this.tokensIndex++) {
           const token = this.tokens[this.tokensIndex];
+
           if (token === ']') {
-            debug('--> unpack array end, %j', arr);
             return arr;
           }
           arr.push(this._unpack());
         }
         return arr;
       }
-      case '$': // object
-      {
-        debug('--> unpack plain object begin');
+      case '$': {
         const obj = {};
         const tokensLen = this.tokens.length;
+
         for (this.tokensIndex++; this.tokensIndex < tokensLen; this.tokensIndex++) {
           const token = this.tokens[this.tokensIndex];
+
           if (token === ']') {
-            debug('--> unpack plain object end, %j', obj);
             return obj;
           }
           const key = this._unpack();
+
           this.tokensIndex++;
           obj[key] = this._unpack();
         }
         return obj;
       }
-      case '*': // buffer
-      {
-        debug('--> unpack buffer begin');
+      case '*': {
         const arr = [];
         const tokensLen = this.tokens.length;
+
         for (this.tokensIndex++; this.tokensIndex < tokensLen; this.tokensIndex++) {
           const token = this.tokens[this.tokensIndex];
+
           if (token === ']') {
-            debug('--> unpack buffer end, %j', arr);
             return new Buffer(arr);
           }
           arr.push(this._unpack());
         }
         return new Buffer(arr);
       }
-      case '#': // error
-      {
-        debug('--> unpack error begin');
+      case '#': {
         const obj = {};
         const tokensLen = this.tokens.length;
+
         for (this.tokensIndex++; this.tokensIndex < tokensLen; this.tokensIndex++) {
           const token = this.tokens[this.tokensIndex];
+
           if (token === ']') {
             const err = new Error(obj.message);
+
             Object.assign(err, obj);
-            debug('--> unpack error end, %j', err);
             return err;
           }
           const key = this._unpack();
+
           this.tokensIndex++;
           obj[key] = this._unpack();
         }
         const err = new Error(obj.message);
+
         Object.assign(err, obj);
         return err;
       }
@@ -133,6 +132,7 @@ class JSONDecoder {
 
     if (arr[0]) {
       const strArr = arr[0].split('|');
+
       for (const str of strArr) {
         this.dictionary.push(this._decodeString(str));
       }
@@ -140,6 +140,7 @@ class JSONDecoder {
 
     if (arr[1]) {
       const intArr = arr[1].split('|');
+
       for (const int of intArr) {
         this.dictionary.push(this._base36To10(int));
       }
@@ -147,6 +148,7 @@ class JSONDecoder {
 
     if (arr[2]) {
       const floatArr = arr[2].split('|');
+
       for (const float of floatArr) {
         this.dictionary.push(parseFloat(float));
       }
@@ -154,16 +156,17 @@ class JSONDecoder {
 
     if (arr[3]) {
       const dateArr = arr[3].split('|');
+
       for (const date of dateArr) {
         this.dictionary.push(this._decodeDate(date));
       }
     }
 
-    debug('decode packed json => %s, with dictionary %j', packed, this.dictionary);
-
     let tmp = '';
+
     for (let i = 0, len = arr[4].length; i < len; ++i) {
       const symbol = arr[4][i];
+
       if (TOKEN_SET.has(symbol)) {
         if (tmp) {
           this.tokens.push(this._base36To10(tmp));

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1,9 +1,5 @@
 'use strict';
 
-const debug = require('debug')('serialize-json#JSONEncoder');
-const is = require('is-type-of');
-const utility = require('utility');
-
 const REG_STR_REPLACER = /[\+ \|\^\%]/g;
 const ENCODER_REPLACER = {
   ' ': '+',
@@ -34,18 +30,19 @@ class JSONEncoder {
     const ast = this._buildAst(json);
 
     let packed = this.dictionary.strings.join('|');
+
     packed += `^${this.dictionary.integers.join('|')}`;
     packed += `^${this.dictionary.floats.join('|')}`;
     packed += `^${this.dictionary.dates.join('|')}`;
     packed += `^${this._pack(ast)}`;
 
-    debug('pack the json => %s', packed);
     return new Buffer(packed);
   }
 
   _pack(ast) {
-    if (is.array(ast)) {
+    if (Array.isArray(ast)) {
       let packed = ast.shift();
+
       for (const item of ast) {
         packed += `${this._pack(item)}|`;
       }
@@ -86,6 +83,7 @@ class JSONEncoder {
 
   _buildStringAst(str) {
     const dictionary = this.dictionary;
+
     if (str === '') {
       return {
         type: 'empty',
@@ -93,6 +91,7 @@ class JSONEncoder {
       };
     }
     const data = this._encodeString(str);
+
     return {
       type: 'string',
       index: dictionary.strings.push(data) - 1,
@@ -101,9 +100,11 @@ class JSONEncoder {
 
   _buildNumberAst(num) {
     const dictionary = this.dictionary;
+
     // integer
     if (num % 1 === 0) {
       const data = this._base10To36(num);
+
       return {
         type: 'integer',
         index: dictionary.integers.push(data) - 1,
@@ -123,30 +124,32 @@ class JSONEncoder {
         index: TOKEN_NULL,
       };
     }
-    if (is.date(obj)) {
+    if (obj instanceof Date) {
       const dictionary = this.dictionary;
       const data = this._dateTo36(obj);
+
       return {
         type: 'date',
         index: dictionary.dates.push(data) - 1,
       };
     }
     let ast;
-    if (is.array(obj)) {
+
+    if (Array.isArray(obj)) {
       ast = [ '@' ];
       for (const item of obj) {
         ast.push(this._buildAst(item));
       }
       return ast;
     }
-    if (is.buffer(obj)) {
+    if (Buffer.isBuffer(obj)) {
       ast = [ '*' ];
       for (const item of obj.values()) {
         ast.push(this._buildAst(item));
       }
       return ast;
     }
-    if (is.error(obj)) {
+    if (obj instanceof Error) {
       ast = [ '#' ];
       ast.push(this._buildAst('message'));
       ast.push(this._buildAst(obj.message));
@@ -157,7 +160,8 @@ class JSONEncoder {
     }
     for (const key in obj) {
       // support object without prototype, like: Object.create(null)
-      if (!utility.has(obj, key)) {
+      if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+      // if (!utility.has(obj, key)) {
         continue;
       }
       ast.push(this._buildAst(key));
@@ -168,7 +172,6 @@ class JSONEncoder {
 
   _buildAst(item) {
     const type = typeof item;
-    debug('calling buildAst with type: %s and data: %j', type, item);
 
     switch (type) {
       case 'string':
@@ -188,7 +191,6 @@ class JSONEncoder {
       case 'object':
         return this._buildObjectAst(item);
       default:
-        debug('unsupported type: %s, return null', type);
         return {
           type: 'null',
           index: TOKEN_NULL,

--- a/package.json
+++ b/package.json
@@ -29,12 +29,8 @@
     "url": "https://github.com/node-modules/serialize-json/issues"
   },
   "homepage": "https://github.com/node-modules/serialize-json#readme",
-  "dependencies": {
-    "debug": "^3.0.1",
-    "is-type-of": "^1.2.0",
-    "utility": "^1.12.0"
-  },
   "devDependencies": {
+    "is-type-of": "^1.2.0",
     "autod": "^2.9.0",
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.4",


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines (I'm not sure where's this guidelines)

##### Description of change
There were three dependencies `debug`, `is-type-of` and `utility`. `debug` was I believe for just logs which we don't need in production. `utility`'s `has` method may be replaced by `Object.prototype.hasOwnProperty`. `is-type-of` methods have also simple replacements. I checked the actual implementation of those methods and they're basically doing the same thing. By removing the dependencies we solved our problem which was about increasing the final bundle size (mainly because of the `is-type-of`'s dependency of `utils`).